### PR TITLE
Add BM25 ranking

### DIFF
--- a/src/commonMain/kotlin/search/TextFieldIndex.kt
+++ b/src/commonMain/kotlin/search/TextFieldIndex.kt
@@ -1,11 +1,16 @@
 package search
 
 import kotlin.math.log10
+import kotlin.math.ln
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 typealias Hit = Pair<String, Double>
 typealias Hits = List<Hit>
+
+enum class RankingAlgorithm { TFIDF, BM25 }
+
+data class BM25Config(val k1: Double = 1.5, val b: Double = 0.75)
 
 @Serializable
 data class TermPos(val id: String, val position:Int)
@@ -21,6 +26,8 @@ data class TextFieldIndexState(
 class TextFieldIndex(
     val analyzer: Analyzer = Analyzer(),
     val queryAnalyzer: Analyzer = Analyzer(),
+    val rankingAlgorithm: RankingAlgorithm = RankingAlgorithm.TFIDF,
+    val bm25Config: BM25Config = BM25Config(),
     private val termCounts: MutableMap<String, Int> = mutableMapOf(),
     private val reverseMap: MutableMap<String, MutableList<TermPos>> = mutableMapOf(),
     private val trie: SimpleStringTrie = SimpleStringTrie()
@@ -30,7 +37,10 @@ class TextFieldIndex(
     override fun loadState(fieldIndexState: IndexState): FieldIndex {
         if(fieldIndexState is TextFieldIndexState) {
             return TextFieldIndex(
-                analyzer = analyzer, queryAnalyzer = queryAnalyzer,
+                analyzer = analyzer,
+                queryAnalyzer = queryAnalyzer,
+                rankingAlgorithm = rankingAlgorithm,
+                bm25Config = bm25Config,
                 termCounts = fieldIndexState.termCounts.toMutableMap(),
                 reverseMap = fieldIndexState.reverseMap.map { (k, v) -> k to v.toMutableList() }.toMap()
                     .toMutableMap(),
@@ -66,7 +76,7 @@ class TextFieldIndex(
             trie.match(term).flatMap { t -> termMatches(t) ?: listOf() }.distinct().takeIf { it.isNotEmpty() }
         } else null
 
-        return matches?.let { calculateTfIdf(it.map { it.id }) } ?: emptyList()
+        return matches?.let { calculateScore(it.map { it.id }) } ?: emptyList()
     }
 
     fun searchPhrase(terms: List<String>, slop: Int = 0): List<Hit> {
@@ -90,13 +100,13 @@ class TextFieldIndex(
             }
         }
 
-        return calculateTfIdf(phraseMatches)
+        return calculateScore(phraseMatches)
     }
 
     fun searchPrefix(prefix: String): List<Hit> {
         val terms = trie.match(prefix)
         val docIds = terms.flatMap { termMatches(it)?.map { it.id } ?: listOf() }.distinct()
-        return calculateTfIdf(docIds)
+        return calculateScore(docIds)
     }
 
     fun termMatches(term: String): List<TermPos>? {
@@ -142,6 +152,13 @@ class TextFieldIndex(
         }.distinct().map { it to 1.0 }.toList()
     }
 
+    private fun calculateScore(docIds: List<String>?): List<Pair<String, Double>> {
+        return when(rankingAlgorithm) {
+            RankingAlgorithm.TFIDF -> calculateTfIdf(docIds)
+            RankingAlgorithm.BM25 -> calculateBm25(docIds)
+        }
+    }
+
     private fun calculateTfIdf(docIds: List<String>?): List<Pair<String, Double>> {
         val termCountsPerDoc = mutableMapOf<String, Int>()
         val matchedDocs = mutableSetOf<String>()
@@ -165,6 +182,30 @@ class TextFieldIndex(
             docId to tfIdf
         }
         return unsorted.sortedByDescending { (_, tfIdf) -> tfIdf }
+    }
+
+    private fun calculateBm25(docIds: List<String>?): List<Pair<String, Double>> {
+        val termCountsPerDoc = mutableMapOf<String, Int>()
+        val matchedDocs = mutableSetOf<String>()
+        docIds?.forEach { docId ->
+            termCountsPerDoc[docId] = termCountsPerDoc.getOrElse(docId) { 0 } + 1
+            matchedDocs.add(docId)
+        }
+        val df = matchedDocs.size.toDouble()
+        val totalDocs = termCounts.size.toDouble()
+        val avgDocLength = if (totalDocs == 0.0) 0.0 else termCounts.values.average()
+        val idf = if (df == 0.0) 0.0 else ln(1.0 + (totalDocs - df + 0.5) / (df + 0.5))
+
+        val unsorted = termCountsPerDoc.map { (docId, termCount) ->
+            val wordCountForDoc = wordCount(docId).toDouble()
+            val tf = termCount.toDouble()
+            val numerator = tf * (bm25Config.k1 + 1)
+            val denominator = tf + bm25Config.k1 * (1 - bm25Config.b + bm25Config.b * (wordCountForDoc / avgDocLength))
+            val score = if (denominator == 0.0) 0.0 else idf * numerator / denominator
+            docId to score
+        }
+
+        return unsorted.sortedByDescending { it.second }
     }
 
     private fun wordCount(docId: String) = termCounts[docId] ?: 0

--- a/src/commonTest/kotlin/QueryTest.kt
+++ b/src/commonTest/kotlin/QueryTest.kt
@@ -13,7 +13,7 @@ class QueryTest {
 
     @Test
     fun shouldReturnDocs() {
-        RankingAlgorithm.values().forEach { alg ->
+        RankingAlgorithm.entries.forEach { alg ->
             val index = testIndex(alg)
             val results = index.search {
                 from=0
@@ -26,7 +26,7 @@ class QueryTest {
 
     @Test
     fun shouldFindShakespeare() {
-        RankingAlgorithm.values().forEach { alg ->
+        RankingAlgorithm.entries.forEach { alg ->
             val index = quotesIndex(alg)
             index.documents.size shouldBeGreaterThan 0
             val results = index.search {
@@ -45,7 +45,7 @@ class QueryTest {
 
     @Test
     fun shouldDoPhraseSearch() {
-        RankingAlgorithm.values().forEach { alg ->
+        RankingAlgorithm.entries.forEach { alg ->
             val index = quotesIndex(alg)
             val results= index.search {
                 query = MatchPhrase("description", "to be or not to be")
@@ -57,7 +57,7 @@ class QueryTest {
 
     @Test
     fun shouldBoostThings() {
-        RankingAlgorithm.values().forEach { alg ->
+        RankingAlgorithm.entries.forEach { alg ->
             val index = quotesIndex(alg)
             index.search {
                 query = BoolQuery(
@@ -75,7 +75,7 @@ class QueryTest {
 
     @Test
     fun shouldIncludePrefixes() {
-        RankingAlgorithm.values().forEach { alg ->
+        RankingAlgorithm.entries.forEach { alg ->
             val index = quotesIndex(alg)
             index.search {
                 query = MatchQuery(SampleObject::description.name, "ba")

--- a/src/commonTest/kotlin/QueryTest.kt
+++ b/src/commonTest/kotlin/QueryTest.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.string.shouldStartWith
 import search.BoolQuery
 import search.MatchAll
 import search.MatchQuery
+import search.RankingAlgorithm
 import search.search
 import kotlin.test.Test
 import search.MatchPhrase
@@ -12,66 +13,76 @@ class QueryTest {
 
     @Test
     fun shouldReturnDocs() {
-        val index = testIndex()
-        val results = index.search {
-            from=0
-            limit=3
-            query = MatchAll()
+        RankingAlgorithm.values().forEach { alg ->
+            val index = testIndex(alg)
+            val results = index.search {
+                from=0
+                limit=3
+                query = MatchAll()
+            }
+            results.size shouldBe 3
         }
-        results.size shouldBe 3
     }
 
     @Test
     fun shouldFindShakespeare() {
-        val index = quotesIndex()
-        index.documents.size shouldBeGreaterThan 0
-        val results = index.search {
-            query = BoolQuery(
-                should = listOf(
-                    MatchQuery(SampleObject::description.name, "to be")
+        RankingAlgorithm.values().forEach { alg ->
+            val index = quotesIndex(alg)
+            index.documents.size shouldBeGreaterThan 0
+            val results = index.search {
+                query = BoolQuery(
+                    should = listOf(
+                        MatchQuery(SampleObject::description.name, "to be")
+                    )
                 )
-            )
-        }
-        results.size shouldBeGreaterThan 0
-        results.forEach { (id,score) ->
-            println(id + " " + score + " " + index.documents[id]?.let { "${it.fields["description"]} (${it.fields["title"]})" })
+            }
+            results.size shouldBeGreaterThan 0
+            results.forEach { (id,score) ->
+                println(id + " " + score + " " + index.documents[id]?.let { "${it.fields["description"]} (${it.fields["title"]})" })
+            }
         }
     }
 
     @Test
     fun shouldDoPhraseSearch() {
-        val index = quotesIndex()
-        val results= index.search {
-            query = MatchPhrase("description", "to be or not to be")
+        RankingAlgorithm.values().forEach { alg ->
+            val index = quotesIndex(alg)
+            val results= index.search {
+                query = MatchPhrase("description", "to be or not to be")
+            }
+            // should find the shakespeare quote and nothing else
+            results.size shouldBe 1
         }
-        // should find the shakespeare quote and nothing else
-        results.size shouldBe 1
     }
 
     @Test
     fun shouldBoostThings() {
-        val index = quotesIndex()
-        index.search {
-            query = BoolQuery(
-                should = listOf(
-                    MatchQuery(SampleObject::description.name, "to be", boost = 0.5),
-                    MatchQuery(SampleObject::description.name, "basic", boost = 20.0)
+        RankingAlgorithm.values().forEach { alg ->
+            val index = quotesIndex(alg)
+            index.search {
+                query = BoolQuery(
+                    should = listOf(
+                        MatchQuery(SampleObject::description.name, "to be", boost = 0.5),
+                        MatchQuery(SampleObject::description.name, "basic", boost = 20.0)
+                    )
                 )
-            )
-        }.first().let { (id,_) ->
-            // partial match for to be wins here because the massive boost on basic
-            index.get(id)?.fields?.get(SampleObject::title.name)?.first() shouldStartWith "Philip K. Dick"
+            }.first().let { (id,_) ->
+                // partial match for to be wins here because the massive boost on basic
+                index.get(id)?.fields?.get(SampleObject::title.name)?.first() shouldStartWith "Philip K. Dick"
+            }
         }
     }
 
     @Test
     fun shouldIncludePrefixes() {
-        val index = quotesIndex()
-        index.search {
-            query = MatchQuery(SampleObject::description.name, "ba")
-        }.size shouldBe 0
-        index.search {
-            query = MatchQuery(SampleObject::description.name, "ba", prefixMatch = true)
-        }.size shouldBeGreaterThan 0
+        RankingAlgorithm.values().forEach { alg ->
+            val index = quotesIndex(alg)
+            index.search {
+                query = MatchQuery(SampleObject::description.name, "ba")
+            }.size shouldBe 0
+            index.search {
+                query = MatchQuery(SampleObject::description.name, "ba", prefixMatch = true)
+            }.size shouldBeGreaterThan 0
+        }
     }
 }

--- a/src/commonTest/kotlin/RankingTest.kt
+++ b/src/commonTest/kotlin/RankingTest.kt
@@ -1,0 +1,44 @@
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.doubles.plusOrMinus
+import search.*
+import kotlin.test.Test
+
+class RankingTest {
+    private fun createDocs(): List<Document> {
+        return listOf(
+            Document("1", mapOf("text" to listOf("foo foo foo bar"))),
+            Document("2", mapOf("text" to listOf("foo bar bar bar"))),
+            Document("3", mapOf("text" to listOf("bar bar bar bar")))
+        )
+    }
+
+    private fun index(algorithm: RankingAlgorithm): DocumentIndex {
+        val index = DocumentIndex(mutableMapOf("text" to TextFieldIndex(rankingAlgorithm = algorithm)))
+        createDocs().forEach(index::index)
+        return index
+    }
+
+    @Test
+    fun rankingShouldWorkForBothAlgorithms() {
+        val tfidf = index(RankingAlgorithm.TFIDF)
+        val bm25 = index(RankingAlgorithm.BM25)
+        tfidf.search(MatchQuery("text", "foo")).first().first shouldBe "1"
+        bm25.search(MatchQuery("text", "foo")).first().first shouldBe "1"
+    }
+
+    @Test
+    fun bm25ScoresShouldMatchLucene() {
+        val bm25 = index(RankingAlgorithm.BM25)
+        val results = bm25.search(MatchQuery("text", "foo"))
+        // expected scores calculated with Lucene's BM25 formula
+        val expected = listOf(
+            "1" to 0.783339382076226,
+            "2" to 0.4700036292457356
+        )
+        results.size shouldBe expected.size
+        results[0].first shouldBe expected[0].first
+        results[0].second shouldBe (expected[0].second plusOrMinus 1e-6)
+        results[1].first shouldBe expected[1].first
+        results[1].second shouldBe (expected[1].second plusOrMinus 1e-6)
+    }
+}

--- a/src/commonTest/kotlin/testfixture.kt
+++ b/src/commonTest/kotlin/testfixture.kt
@@ -1,6 +1,7 @@
 import search.Document
 import search.DocumentIndex
 import search.TextFieldIndex
+import search.RankingAlgorithm
 import kotlin.random.Random
 import search.Analyzer
 import search.KeywordTokenizer
@@ -20,12 +21,14 @@ data class SampleObject(
     )
 }
 
-fun testIndex(): DocumentIndex {
+fun testIndex(
+    algorithm: RankingAlgorithm = RankingAlgorithm.TFIDF
+): DocumentIndex {
     val documentIndex = DocumentIndex(
         mutableMapOf(
-            "title" to TextFieldIndex(),
-            "description" to TextFieldIndex(),
-            "tags" to TextFieldIndex(),
+            "title" to TextFieldIndex(rankingAlgorithm = algorithm),
+            "description" to TextFieldIndex(rankingAlgorithm = algorithm),
+            "tags" to TextFieldIndex(rankingAlgorithm = algorithm),
         )
     )
 
@@ -62,11 +65,13 @@ fun testIndex(): DocumentIndex {
 }
 
 
-fun quotesIndex(): DocumentIndex {
+fun quotesIndex(
+    algorithm: RankingAlgorithm = RankingAlgorithm.TFIDF
+): DocumentIndex {
     val documentIndex = DocumentIndex(
         mutableMapOf(
-            "title" to TextFieldIndex(),
-            "description" to TextFieldIndex(),
+            "title" to TextFieldIndex(rankingAlgorithm = algorithm),
+            "description" to TextFieldIndex(rankingAlgorithm = algorithm),
             "tags" to TextFieldIndex(
                 analyzer = Analyzer(
                     textFilters = listOf(),


### PR DESCRIPTION
## Summary
- support selecting between TF-IDF and BM25 in `TextFieldIndex`
- implement BM25 scoring
- test ranking for both algorithms and verify BM25 matches lucene

## Testing
- `./gradlew jvmTest --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68428928e2d0832e86d5165b3c352880