### PR TITLE
Add bigram vector and test for vector search

### DIFF
--- a/src/commonMain/kotlin/search/syntactic.kt
+++ b/src/commonMain/kotlin/search/syntactic.kt
@@ -1,0 +1,34 @@
+package search
+
+/**
+ * Generate a [Vector] with counts for all character bigrams.
+ * Tokens are normalized to base36 (0-9,a-z) before processing.
+ */
+fun bigramVector(tokens: List<String>): Vector {
+    val dims = 36 * 36
+    val vector = MutableList(dims) { 0.0 }
+
+    fun idx(c: Char): Int? = when(c) {
+        in '0'..'9' -> c - '0'
+        in 'a'..'z' -> c - 'a' + 10
+        in 'A'..'Z' -> c - 'A' + 10
+        else -> null
+    }
+
+    tokens.forEach { token ->
+        val chars = token.filter { it.isLetterOrDigit() }.lowercase()
+        if (chars.length > 1) {
+            val codes = chars.mapNotNull { idx(it) }
+            for(i in 0 until codes.size - 1) {
+                val index = codes[i] * 36 + codes[i + 1]
+                vector[index] = vector[index] + 1.0
+            }
+        }
+    }
+    return vector
+}
+
+fun bigramVector(text: String, analyzer: Analyzer = Analyzer()): Vector =
+    bigramVector(analyzer.analyze(text))
+
+

--- a/src/commonTest/kotlin/SyntacticVectorTest.kt
+++ b/src/commonTest/kotlin/SyntacticVectorTest.kt
@@ -1,0 +1,33 @@
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+import kotlin.random.Random
+import search.VectorFieldIndex
+import search.bigramVector
+import search.quotesIndex
+import search.Analyzer
+
+class SyntacticVectorTest {
+    private val analyzer = Analyzer()
+
+    @Test
+    fun shouldFindHamletViaVectorSearch() {
+        val docs = quotesIndex()
+        val index = VectorFieldIndex(4, 36 * 36, Random(42))
+
+        docs.documents.forEach { (id, doc) ->
+            val text = doc.fields["description"]?.joinToString(" ") ?: ""
+            val vec = bigramVector(analyzer.analyze(text))
+            index.insert(id, listOf(vec))
+        }
+
+        val queryVec = bigramVector(analyzer.analyze("to be or not to be"))
+        val result = index.query(queryVec, 1)
+
+        val hamletId = docs.documents.entries.first { entry ->
+            entry.value.fields["title"]?.any { it.contains("Hamlet") } == true
+        }.key
+
+        result.first().first shouldBe hamletId
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `bigramVector` helper that converts tokens to a 36×36 frequency vector of normalized bigrams
- add `SyntacticVectorTest` verifying vector search using bigram vectors on the quotes fixture

## Testing
- `./gradlew assemble jvmTest` *(fails: Calculating task graph)*

------
https://chatgpt.com/codex/tasks/task_e_6843008de7e4832eb5a2d8ea7eb3c405