### PR TITLE
Add geospatial indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,5 +156,19 @@ index.documents.forEach { (id, doc) ->
 val nearest = vectorIndex.query(bigramVector("to be"), 3)
 ```
 
+### Geo search
+
+```kotlin
+val geoIndex = GeoFieldIndex()
+val geoDoc = Document(
+    id = "berlin",
+    fields = mapOf("location" to listOf(Geometry.Point.of(13.4,52.5).toString()))
+)
+val index = DocumentIndex(mutableMapOf("location" to geoIndex))
+index.index(geoDoc)
+val bbox = doubleArrayOf(13.0,52.0,14.0,53.0).toGeometry().coordinates!!
+val results = index.search { query = GeoPolygonQuery("location", bbox) }
+```
+
 Currently there are a handful of queries supported. `BoolQuery` is loosely styled after the Elasticsearch/OpenSearch bool query. Same for `MatchQuery`, `MatchPhrase`, `TermQuery`, `RangeQuery` and `MatchAll`.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,6 +100,7 @@ kotlin {
                 implementation(kotlin("stdlib-common"))
                 implementation("com.jillesvangurp:kotlinx-serialization-extensions:_")
                 implementation(KotlinX.serialization.json)
+                implementation("com.github.jillesvangurp:geogeometry:_")
             }
         }
         commonTest {

--- a/src/commonMain/kotlin/search/DocumentIndex.kt
+++ b/src/commonMain/kotlin/search/DocumentIndex.kt
@@ -44,8 +44,9 @@ class DocumentIndex(
             }
 
             texts.forEach {
-                if(fieldIndex is TextFieldIndex) {
-                    fieldIndex.add(document.id, it)
+                when(fieldIndex) {
+                    is TextFieldIndex -> fieldIndex.add(document.id, it)
+                    is GeoFieldIndex -> fieldIndex.add(document.id, it)
                 }
             }
         }

--- a/src/commonMain/kotlin/search/GeoFieldIndex.kt
+++ b/src/commonMain/kotlin/search/GeoFieldIndex.kt
@@ -1,0 +1,96 @@
+package search
+
+import com.jillesvangurp.geo.GeoGeometry
+import com.jillesvangurp.geo.GeoHashUtils
+import com.jillesvangurp.geojson.Geometry
+import com.jillesvangurp.geojson.PolygonCoordinates
+import com.jillesvangurp.serializationext.DEFAULT_JSON
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("GeoFieldIndexState")
+data class GeoFieldIndexState(
+    val precision: Int,
+    val geohashMap: Map<String, List<String>>,
+    val documents: Map<String, String>
+) : IndexState
+
+class GeoFieldIndex(
+    private val precision: Int = 5,
+    private val geohashMap: MutableMap<String, MutableList<String>> = mutableMapOf(),
+    private val documents: MutableMap<String, String> = mutableMapOf()
+) : FieldIndex {
+    override val indexState: IndexState
+        get() = GeoFieldIndexState(precision, geohashMap, documents)
+
+    override fun loadState(fieldIndexState: IndexState): FieldIndex {
+        if (fieldIndexState is GeoFieldIndexState) {
+            val loaded = GeoFieldIndex(
+                precision = fieldIndexState.precision,
+                geohashMap = fieldIndexState.geohashMap.mapValues { it.value.toMutableList() }.toMutableMap(),
+                documents = fieldIndexState.documents.toMutableMap()
+            )
+            return loaded
+        }
+        error("wrong index type; expecting GeoFieldIndexState but was ${fieldIndexState::class.simpleName}")
+    }
+
+    fun add(docId: String, geoJson: String) {
+        documents[docId] = geoJson
+        val geometry = DEFAULT_JSON.decodeFromString(Geometry.serializer(), geoJson)
+        geohashesForGeometry(geometry).flatMap { normalizeHash(it) }.forEach { hash ->
+            geohashMap.getOrPut(hash) { mutableListOf() }.add(docId)
+        }
+    }
+
+    private fun geohashesForGeometry(geometry: Geometry): Set<String> = when (geometry) {
+        is Geometry.Point -> geometry.coordinates?.let { setOf(GeoHashUtils.encode(it[1], it[0], precision)) } ?: emptySet()
+        is Geometry.Polygon -> geometry.coordinates?.let { GeoHashUtils.geoHashesForPolygon(it, maxLength = precision, includePartial = true) } ?: emptySet()
+        is Geometry.MultiPolygon -> geometry.coordinates?.let { GeoHashUtils.geoHashesForMultiPolygon(it, maxLength = precision, includePartial = true) } ?: emptySet()
+        else -> emptySet()
+    }
+
+    private fun normalizeHash(hash: String): Set<String> {
+        var hashes = setOf(hash)
+        while (hashes.first().length < precision) {
+            hashes = hashes.flatMap { GeoHashUtils.subHashes(it).toList() }.toSet()
+        }
+        return hashes.map { if (it.length > precision) it.substring(0, precision) else it }.toSet()
+    }
+
+    fun queryPoint(lat: Double, lon: Double): List<String> {
+        val hash = GeoHashUtils.encode(lat, lon, precision)
+        val ids = geohashMap[hash] ?: return emptyList()
+        return ids.filter { verifyPoint(it, lat, lon) }
+    }
+
+    private fun verifyPoint(docId: String, lat: Double, lon: Double): Boolean {
+        val geoJson = documents[docId] ?: return false
+        val geometry = DEFAULT_JSON.decodeFromString(Geometry.serializer(), geoJson)
+        return when (geometry) {
+            is Geometry.Point -> geometry.coordinates?.let { it[0] == lon && it[1] == lat } ?: false
+            is Geometry.Polygon -> geometry.coordinates?.let { GeoGeometry.polygonContains(lat, lon, it) } ?: false
+            is Geometry.MultiPolygon -> geometry.coordinates?.any { GeoGeometry.polygonContains(lat, lon, it) } ?: false
+            else -> false
+        }
+    }
+
+    fun queryPolygon(polygon: PolygonCoordinates): List<String> {
+        val hashes = GeoHashUtils.geoHashesForPolygon(polygon, maxLength = precision, includePartial = true)
+            .flatMap { normalizeHash(it) }
+        val candidates = hashes.flatMap { geohashMap[it].orEmpty() }.distinct()
+        return candidates.filter { verifyPolygon(it, polygon) }
+    }
+
+    private fun verifyPolygon(docId: String, polygon: PolygonCoordinates): Boolean {
+        val geoJson = documents[docId] ?: return false
+        val geometry = DEFAULT_JSON.decodeFromString(Geometry.serializer(), geoJson)
+        return when (geometry) {
+            is Geometry.Point -> geometry.coordinates?.let { GeoGeometry.polygonContains(it[1], it[0], polygon) } ?: false
+            is Geometry.Polygon -> geometry.coordinates?.let { GeoGeometry.overlap(it, polygon) || GeoGeometry.contains(polygon[0], it[0]) || GeoGeometry.contains(it[0], polygon[0]) } ?: false
+            is Geometry.MultiPolygon -> geometry.coordinates?.any { GeoGeometry.overlap(it, polygon) } ?: false
+            else -> false
+        }
+    }
+}

--- a/src/commonMain/kotlin/search/geo-queries.kt
+++ b/src/commonMain/kotlin/search/geo-queries.kt
@@ -1,0 +1,30 @@
+package search
+
+import com.jillesvangurp.geojson.PolygonCoordinates
+
+class GeoPointQuery(
+    private val field: String,
+    private val latitude: Double,
+    private val longitude: Double,
+    override val boost: Double? = null,
+) : Query {
+    override fun hits(documentIndex: DocumentIndex, context: QueryContext): Hits {
+        val index = documentIndex.getFieldIndex(field)
+        return if (index is GeoFieldIndex) {
+            index.queryPoint(latitude, longitude).map { it to 1.0 }.boost(normalizedBoost)
+        } else emptyList()
+    }
+}
+
+class GeoPolygonQuery(
+    private val field: String,
+    private val polygon: PolygonCoordinates,
+    override val boost: Double? = null,
+) : Query {
+    override fun hits(documentIndex: DocumentIndex, context: QueryContext): Hits {
+        val index = documentIndex.getFieldIndex(field)
+        return if (index is GeoFieldIndex) {
+            index.queryPolygon(polygon).map { it to 1.0 }.boost(normalizedBoost)
+        } else emptyList()
+    }
+}

--- a/src/commonTest/kotlin/GeoIndexTest.kt
+++ b/src/commonTest/kotlin/GeoIndexTest.kt
@@ -1,0 +1,30 @@
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import kotlin.test.Test
+import search.Document
+import search.DocumentIndex
+import search.GeoFieldIndex
+import search.GeoPointQuery
+import search.GeoPolygonQuery
+import search.search
+import com.jillesvangurp.geojson.Geometry
+import com.jillesvangurp.geojson.toGeometry
+
+class GeoIndexTest {
+    @Test
+    fun testGeoQueries() {
+        val geoIndex = GeoFieldIndex()
+        val index = DocumentIndex(mutableMapOf("loc" to geoIndex))
+        val berlin = Geometry.Point.of(13.4, 52.5)
+        val paris = Geometry.Point.of(2.35, 48.85)
+        index.index(Document("berlin", mapOf("loc" to listOf(berlin.toString()))))
+        index.index(Document("paris", mapOf("loc" to listOf(paris.toString()))))
+
+        val hits = index.search { query = GeoPointQuery("loc", 52.5, 13.4) }
+        hits.map { it.first } shouldContain "berlin"
+
+        val polygon = doubleArrayOf(12.0, 52.0, 14.0, 53.0).toGeometry().coordinates!!
+        val polyHits = index.search { query = GeoPolygonQuery("loc", polygon) }
+        polyHits.map { it.first } shouldContainExactlyInAnyOrder listOf("berlin")
+    }
+}

--- a/versions.properties
+++ b/versions.properties
@@ -17,4 +17,6 @@ version.kotest=5.9.1
 
 version.com.jillesvangurp..kotlinx-serialization-extensions=1.0.4
 
+version.com.github.jillesvangurp..geogeometry=3.4.22
+
 version.kotlinx.serialization=1.7.3


### PR DESCRIPTION
## Summary
- add GeoFieldIndex with geohash-based indexing
- implement GeoPointQuery and GeoPolygonQuery
- wire geometry fields into DocumentIndex
- document new geo search capability
- test geo index functionality

## Testing
- `./gradlew jvmTest`
- ❌ `./gradlew jsTest` *(failed: Internal compiler error)*

------
https://chatgpt.com/codex/tasks/task_e_68442e7ba118832eb680116815a681d5